### PR TITLE
feat: Implement login check for extension popup

### DIFF
--- a/src/Popup.svelte
+++ b/src/Popup.svelte
@@ -1,16 +1,60 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+
   let iframeUrl = '';
+  let authStatus: 'checking' | 'loggedIn' | 'loggedOut' = 'checking';
+  let errorMessage = '';
+
+  const loginUrl = 'https://reference-radar.vercel.app/login'; // Define login URL
 
   onMount(() => {
-    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-      const url = encodeURIComponent(tabs[0]?.url || '');
-      const title = encodeURIComponent(tabs[0]?.title || '');
+    chrome.runtime.sendMessage({ type: 'AUTH_CHECK' }, (response) => {
+      if (chrome.runtime.lastError) {
+        // Handle errors from chrome.runtime.sendMessage itself
+        console.error('Error sending message to background:', chrome.runtime.lastError.message);
+        errorMessage = 'Error checking authentication status. Please try again.';
+        authStatus = 'loggedOut'; // Or a specific error state
+        return;
+      }
 
-      // 👇 Replace with your live SvelteKit route
-      iframeUrl = `https://reference-radar.vercel.app/create-reference?embed=true&url=${url}&title=${title}`;
+      if (response) {
+        if (response.loggedIn) {
+          authStatus = 'loggedIn';
+          // Construct iframe URL only if logged in
+          chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+            if (chrome.runtime.lastError) {
+                console.error('Error querying tabs:', chrome.runtime.lastError.message);
+                errorMessage = 'Could not get current tab information.';
+                authStatus = 'loggedOut'; // Or handle error appropriately
+                return;
+            }
+            const currentTab = tabs[0];
+            if (currentTab) {
+              const url = encodeURIComponent(currentTab.url || '');
+              const title = encodeURIComponent(currentTab.title || '');
+              iframeUrl = `https://reference-radar.vercel.app/create-reference?embed=true&url=${url}&title=${title}`;
+            } else {
+                errorMessage = 'Could not get current tab information.';
+                authStatus = 'loggedOut'; // Or handle error appropriately
+            }
+          });
+        } else {
+          authStatus = 'loggedOut';
+          if (response.error) {
+            errorMessage = `Authentication check failed: ${response.error}`;
+          } else {
+            errorMessage = 'You are not logged in to Reference Radar.';
+          }
+        }
+      } else {
+        // No response, which can happen if background script has an issue
+        // or doesn't call sendResponse
+        errorMessage = 'No response from authentication check.';
+        authStatus = 'loggedOut';
+      }
     });
 
+    // Keep existing message listener for when reference is added
     window.addEventListener('message', (event) => {
       if (event.data === 'reference-added') {
         window.close();
@@ -20,13 +64,53 @@
 </script>
 
 <main class="w-[22rem] h-[34rem] overflow-hidden">
-  {#if iframeUrl}
-    <iframe
-      src={iframeUrl}
-      class="w-full h-full border-0"
-      sandbox="allow-scripts allow-same-origin allow-forms"
-    />
-  {:else}
-    <p class="p-4 text-sm">Loading…</p>
+  {#if authStatus === 'checking'}
+    <p class="p-4 text-sm">Checking authentication status...</p>
+  {:else if authStatus === 'loggedIn'}
+    {#if iframeUrl}
+      <iframe
+        src={iframeUrl}
+        class="w-full h-full border-0"
+        sandbox="allow-scripts allow-same-origin allow-forms"
+      />
+    {:else}
+      <p class="p-4 text-sm">Loading Reference Radar...</p>
+      <!-- This state could occur briefly if tabs.query is slow or errors -->
+      {#if errorMessage}
+        <p class="p-4 text-sm text-red-600">{errorMessage}</p>
+      {/if}
+    {/if}
+  {:else if authStatus === 'loggedOut'}
+    <div class="p-4 text-sm">
+      <p>{errorMessage || 'Please log in to Reference Radar to save references.'}</p>
+      <a
+        href={loginUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="mt-2 inline-block px-4 py-2 text-white bg-blue-600 hover:bg-blue-700 rounded"
+      >
+        Go to Login
+      </a>
+    </div>
   {/if}
 </main>
+
+<style>
+  /* Add some basic styling for the link/button if not using Tailwind or similar */
+  .button-link {
+    display: inline-block;
+    padding: 8px 12px;
+    margin-top: 10px;
+    color: white;
+    background-color: #007bff;
+    text-decoration: none;
+    border-radius: 4px;
+    text-align: center;
+  }
+  .button-link:hover {
+    background-color: #0056b3;
+  }
+  .text-red-600 { /* Simple error color if not using Tailwind */
+    color: #dc2626;
+  }
+</style>

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,0 +1,26 @@
+// src/background.ts
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.type === 'AUTH_CHECK') {
+    const targetUrl = 'https://reference-radar.vercel.app/create-reference';
+    // We fetch the page that is normally loaded into the iframe.
+    // If the user is logged in to reference-radar.vercel.app,
+    // the browser should automatically send cookies.
+    fetch(targetUrl, { credentials: 'include' })
+      .then(response => {
+        // If the response is OK and the final URL after redirects doesn't look like a login page
+        if (response.ok && !response.url.includes('/login') && !response.url.includes('/signin')) {
+          // Assuming that if we get a 200 OK and it's not a login page, the user is authenticated
+          // and the content is what the iframe expects.
+          sendResponse({ loggedIn: true });
+        } else {
+          // Either not response.ok (e.g. 401, 403, 500) or redirected to a login page
+          sendResponse({ loggedIn: false });
+        }
+      })
+      .catch(error => {
+        console.error('Auth check fetch failed:', error);
+        sendResponse({ loggedIn: false, error: error.message });
+      });
+    return true; // Indicates that the response is sent asynchronously
+  }
+});


### PR DESCRIPTION
Adds an authentication check before loading the create-reference iframe:

- Modified `src/background.ts` to include a message listener (`AUTH_CHECK`). This listener fetches `https://reference-radar.vercel.app/create-reference` with `credentials: 'include'` to determine if you have an active session on the main site. It responds with the login status.

- Updated `src/Popup.svelte` to:
  - Send an `AUTH_CHECK` message to the background script on mount.
  - Display different UI states based on the auth status:
    - "Checking authentication..." while waiting for a response.
    - The iframe content if you are logged in.
    - A "Please log in" message and a link to the login page if you are not logged in or if an error occurs.
  - Error handling for message passing and tab querying has been improved.

This change addresses the issue where the iframe would fail to load the reference modal due to you not being authenticated. The extension now guides you to log in if necessary.